### PR TITLE
Resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-result-2
-result
+result*
+bin
 
 # Created by https://www.gitignore.io/api/haskell
 # Edit at https://www.gitignore.io/?templates=haskell

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+echo "Removing previous build artifacts..."
+rm result*
+rm -rf bin
+
+echo "Building grid-label..."
+mkdir bin
+nix-build -A grid-label-linux
+cp result/bin/grid-label bin/grid-label
+echo "Done!"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -22,14 +22,13 @@ data MouseState = Released | Selecting | Deselecting
 data AppState = AppState
   { picZipper  :: PicZip
   , mouseState :: MouseState
+  , picScale :: Float
   }
 
 data Options = Options
   { files  :: [FilePath]
   , width  :: Int
   , height :: Int
-  -- , resX :: Maybe Int
-  -- , resY :: Maybe Int
   }
 
 optparser :: Parser Options
@@ -37,14 +36,12 @@ optparser = Options
   <$> some (strArgument (metavar "FILENAME+" <> help "Input image(s)"))
   <*> option auto (help "Horizontal label resolution" <> short 'w' <> long "width")
   <*> option auto (help "Vertical label resolution" <> short 'h' <> long "height")
-  -- <*> optional (option auto (help "Viewer horizontal resolution" <> long "viewH"))
-  -- <*> optional (option auto (help "Viewer vertical resolution" <> long "viewW"))
 
 imgToPic :: Image PixelRGBA8 -> Picture
 imgToPic (Image w h d) = bitmapOfByteString w h (BitmapFormat TopToBottom PxRGBA) (BS.pack $ V.toList d) True
 
 annotate :: Int -> Int -> Int -> Int -> [(FilePath, Picture)] -> IO ()
-annotate gridW gridH imgW imgH images =
+annotate gridW gridH imgW imgH images = 
   playIO (InWindow "Annotate" (imgW,imgH) (0,0))
         black
         60
@@ -53,34 +50,34 @@ annotate gridW gridH imgW imgH images =
         handle
         step
   where
-    imgW' = fromIntegral imgW
-    imgH' = fromIntegral imgH
     gridW' = fromIntegral gridW
     gridH' = fromIntegral gridH
-
+    imgW' = fromIntegral imgW
+    imgH' = fromIntegral imgH
     dx = imgW' / gridW'
     dy = imgH' / gridH'
 
-    imgToGrid :: (Float, Float) -> (Int, Int)
-    imgToGrid (x,y) = (floor $ (x + imgW'/2)/dx, floor $ (y + imgH'/2)/dy)
+    imgToGrid :: Float -> (Float, Float) -> (Int, Int)
+    imgToGrid s (x,y) = (floor $ (x/s + imgW'/2)/dx, floor $ (y/s + imgH'/2)/dy)
+
     gridToImg :: (Int, Int) -> (Float, Float)
     gridToImg (x,y) = (fromIntegral x * dx - imgW'/2, fromIntegral y * dy - imgH'/2)
 
     initState :: AppState
-    initState = AppState (fromJust . fromList $ fmap (\(fp, img) -> (mempty,fp,img)) images) Released
+    initState = AppState (fromJust . fromList $ fmap (\(fp, img) -> (mempty,fp,img)) images) Released 1
 
-    drawSet set = mconcat $ do
+    drawSet s set = mconcat $ do
       x <- [0 .. gridW - 1]
       y <- [0 .. gridH - 1]
       let gridPos = (x,y)
       let (ox,oy) = gridToImg (x,y)
       let rect = if S.member gridPos set then rectangleSolid else rectangleWire
-      pure . translate (ox + dx/2) (oy + dy/2) $ rect dx dy
+      pure . scale s s . translate (ox + dx/2) (oy + dy/2) $ rect dx dy
 
     draw :: AppState -> IO Picture
-    draw (AppState (Zipper _ (set, fp, pic) _) _) = pure $ mconcat
-      [ pic
-      , drawSet set
+    draw (AppState (Zipper _ (set, fp, pic) _) _ s) = pure $ mconcat
+      [ scale s s pic
+      , drawSet s set
       , color green . translate ((+12) . negate $ imgW'/2) ((+12) . negate $ imgH'/2) . scale 0.2 0.2 . text . takeFileName $ fp
       ]
 
@@ -89,24 +86,30 @@ annotate gridW gridH imgW imgH images =
     stateOp Released    = flip const
 
     handle :: Event -> AppState -> IO AppState
-    handle (EventKey (MouseButton LeftButton) Up _ _) (AppState zipper _) = pure $ AppState zipper Released
-    handle (EventKey (MouseButton LeftButton) Down _ pos) (AppState (Zipper l (set, fp, pic) r) _) = pure $
-      let pos' = imgToGrid pos
+    handle (EventKey (MouseButton LeftButton) Up _ _) (AppState zipper _ s) = pure $ AppState zipper Released s
+    handle (EventKey (MouseButton LeftButton) Down _ pos) (AppState (Zipper l (set, fp, pic) r) _ s) = pure $
+      let pos' = imgToGrid s pos
           mstate' = (if S.member pos' set then Deselecting else Selecting)
-       in AppState (Zipper l (stateOp mstate' pos' set, fp, pic) r) mstate'
+       in AppState (Zipper l (stateOp mstate' pos' set, fp, pic) r) mstate' s
 
-    handle (EventMotion pos) (AppState (Zipper l (set, fp, pic) r) mstate) = pure $ AppState (Zipper l (stateOp mstate (imgToGrid pos) set, fp, pic) r) mstate
+    handle (EventMotion pos) (AppState (Zipper l (set, fp, pic) r) mstate s) = pure $ AppState (Zipper l (stateOp mstate (imgToGrid s pos) set, fp, pic) r) mstate s
 
-    handle (EventKey key Down _ _) (AppState zipper _) | key `elem` leftKeys  = pure $ AppState (goLeft zipper) Released
-    handle (EventKey key Down _ _) (AppState zipper _) | key `elem` rightKeys = pure $ AppState (goRight zipper) Released
-    handle (EventKey key Down _ _) (AppState zipper _) | key `elem` exitKeys = do
+    handle (EventKey key Down _ _) (AppState zipper _ s) | key `elem` leftKeys  = pure $ AppState (goLeft zipper) Released s
+    handle (EventKey key Down _ _) (AppState zipper _ s) | key `elem` rightKeys = pure $ AppState (goRight zipper) Released s
+    handle (EventKey key Down _ _) (AppState zipper _ _) | key `elem` exitKeys = do
       forM_ zipper $ \(set, fp, _) ->
         let image = setToImage set gridW gridH
          in saveBmpImage (fp -<.> "label.bmp") (ImageRGB8 image)
       exitSuccess
+    handle (EventResize (winW,winH)) (AppState zipper _ _) = pure $ AppState zipper Released s
+      where
+        winW' = fromIntegral winW
+        winH' = fromIntegral winH
+        s = if imgW'/imgH' > winW'/winH' then winW' / imgW' else winH' / imgH'
+
     handle _ l = pure l
 
-    exitKeys  = [SpecialKey KeyEsc]
+    exitKeys  = [SpecialKey KeyEsc, Char 'q']
     leftKeys  = [SpecialKey KeyLeft,  Char 'h', Char 'j', Char 'n']
     rightKeys = [SpecialKey KeyRight, Char 'k', Char 'l', Char 'p']
 

--- a/src/Zipper.hs
+++ b/src/Zipper.hs
@@ -11,9 +11,11 @@ fromList []    = Nothing
 
 goLeft, goRight :: Zipper a -> Zipper a
 
-goLeft (Zipper (x:l) f r) = Zipper l x (f:r)
+goLeft (Zipper [] f []) = Zipper [] f []
 goLeft (Zipper [] f r) = goLeft $ Zipper (reverse r) f []
+goLeft (Zipper (x:l) f r) = Zipper l x (f:r)
 
+goRight (Zipper [] f []) = Zipper [] f []
 goRight (Zipper l f (x:r)) = Zipper (f:l) x r
 goRight (Zipper l f []) = goRight $ Zipper [] f (reverse l)
 


### PR DESCRIPTION
  * Adds a simple script that will generate a portable binary
  * the image will scale to fit the window when resizing
  * Fixes a bug where `goLeft/goRight` on an empty zipper causes an infinite loop